### PR TITLE
Replace toast error with console log in QueryClient

### DIFF
--- a/frontend/app/query-client.tsx
+++ b/frontend/app/query-client.tsx
@@ -8,7 +8,7 @@ const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
       if (query.state.data !== undefined) {
-        console.log(
+        console.error(
           `Something went wrong: ${error instanceof Error ? error.message : "Unknown server error"}`,
         );
       }

--- a/frontend/app/query-client.tsx
+++ b/frontend/app/query-client.tsx
@@ -3,13 +3,12 @@
 import React from "react";
 
 import { QueryClientProvider as InternalProvider, QueryCache, QueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
 
 const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: (error, query) => {
       if (query.state.data !== undefined) {
-        toast.error(
+        console.log(
           `Something went wrong: ${error instanceof Error ? error.message : "Unknown server error"}`,
         );
       }


### PR DESCRIPTION
Because of error toasts on functional errors, they will be temporarily removed and will be replaced with a console#log.